### PR TITLE
Add Mapper and Business Layers for Sleep API with Unit Tests

### DIFF
--- a/sleep/src/main/java/com/noom/interview/fullstack/sleep/business/SleepLogCalculator.java
+++ b/sleep/src/main/java/com/noom/interview/fullstack/sleep/business/SleepLogCalculator.java
@@ -1,0 +1,49 @@
+package com.noom.interview.fullstack.sleep.business;
+
+import com.noom.interview.fullstack.sleep.model.MorningFeeling;
+import com.noom.interview.fullstack.sleep.model.SleepLog;
+import com.noom.interview.fullstack.sleep.dto.SleepLogRequest;
+import java.time.LocalTime;
+import java.time.temporal.ChronoUnit;
+import java.util.EnumMap;
+import java.util.List;
+import java.util.Map;
+
+public class SleepLogCalculator {
+
+    public static int calculateTotalTimeInBed(SleepLogRequest request) {
+        return (int) ChronoUnit.MINUTES.between(request.getTimeInBedStart(), request.getTimeInBedEnd());
+    }
+
+    public static double calculateAverageTotalTimeInBed(List<SleepLog> logs) {
+        return logs.stream()
+                .mapToInt(SleepLog::getTotalTimeInBed)
+                .average()
+                .orElse(0.0);
+    }
+
+    public static LocalTime calculateAverageTimeInBed(List<SleepLog> logs) {
+        return LocalTime.ofSecondOfDay((long) logs.stream()
+                .mapToInt(log -> log.getTimeInBedStart().toLocalTime().toSecondOfDay())
+                .average()
+                .orElse(0.0));
+    }
+
+    public static LocalTime calculateAverageTimeOutOfBed(List<SleepLog> logs) {
+        return LocalTime.ofSecondOfDay((long) logs.stream()
+                .mapToInt(log -> log.getTimeInBedEnd().toLocalTime().toSecondOfDay())
+                .average()
+                .orElse(0.0));
+    }
+
+    public static Map<MorningFeeling, Integer> calculateMorningFeelingFrequencies(List<SleepLog> logs) {
+        Map<MorningFeeling, Integer> frequencies = new EnumMap<>(MorningFeeling.class);
+        for (MorningFeeling feeling : MorningFeeling.values()) {
+            frequencies.put(feeling, 0);
+        }
+        for (SleepLog log : logs) {
+            frequencies.merge(log.getMorningFeeling(), 1, Integer::sum);
+        }
+        return frequencies;
+    }
+}

--- a/sleep/src/main/java/com/noom/interview/fullstack/sleep/mapper/SleepLogMapper.java
+++ b/sleep/src/main/java/com/noom/interview/fullstack/sleep/mapper/SleepLogMapper.java
@@ -1,0 +1,79 @@
+package com.noom.interview.fullstack.sleep.mapper;
+
+import java.time.LocalDate;
+import java.time.LocalTime;
+import java.util.Arrays;
+import java.util.stream.Collectors;
+
+import org.springframework.stereotype.Component;
+
+import com.noom.interview.fullstack.sleep.dto.SleepAveragesResponse;
+import com.noom.interview.fullstack.sleep.dto.SleepLogRequest;
+import com.noom.interview.fullstack.sleep.dto.SleepLogResponse;
+import com.noom.interview.fullstack.sleep.model.MorningFeeling;
+import com.noom.interview.fullstack.sleep.model.SleepLog;
+
+@Component
+public class SleepLogMapper {
+
+    public SleepLogRequest toRequest(SleepLog sleepLog) {
+        SleepLogRequest sleepLogRequest = new SleepLogRequest();
+        sleepLogRequest.setTimeInBedStart(sleepLog.getTimeInBedStart());
+        sleepLogRequest.setTimeInBedEnd(sleepLog.getTimeInBedEnd());
+        sleepLogRequest.setMorningFeeling(sleepLog.getMorningFeeling());
+
+        return sleepLogRequest;
+    }
+
+    public SleepLog toEntity(SleepLogRequest sleepLogRequest, Long userId, LocalDate sleepDate, int totalTimeInBed) {
+        SleepLog sleepLog = new SleepLog();
+        sleepLog.setUserId(userId);
+        sleepLog.setSleepDate(sleepDate);
+        sleepLog.setTimeInBedStart(sleepLogRequest.getTimeInBedStart());
+        sleepLog.setTimeInBedEnd(sleepLogRequest.getTimeInBedEnd());
+        sleepLog.setTotalTimeInBed(totalTimeInBed);
+        sleepLog.setMorningFeeling(sleepLogRequest.getMorningFeeling());
+
+        return sleepLog;
+    }
+
+    public SleepLogResponse toResponse(SleepLog sleepLog) {
+        SleepLogResponse sleepLogResponse = new SleepLogResponse();
+        sleepLogResponse.setUserId(sleepLog.getUserId());
+        sleepLogResponse.setSleepDate(sleepLog.getSleepDate());
+        sleepLogResponse.setTimeInBedStart(sleepLog.getTimeInBedStart());
+        sleepLogResponse.setTimeInBedEnd(sleepLog.getTimeInBedEnd());
+        sleepLogResponse.setTotalTimeInBed(sleepLog.getTotalTimeInBed());
+        sleepLogResponse.setMorningFeeling(sleepLog.getMorningFeeling());
+
+        return sleepLogResponse;
+    }
+
+    public SleepAveragesResponse toAverageResponseWithEmptyLogs(LocalDate startDate, LocalDate endDate) {
+        SleepAveragesResponse sleepAveragesResponse = new SleepAveragesResponse();
+        sleepAveragesResponse.setDateRangeStart(startDate);
+        sleepAveragesResponse.setDateRangeEnd(endDate);
+        sleepAveragesResponse.setAverageTotalTimeInBed(0.0);
+        sleepAveragesResponse.setAverageTimeInBed(LocalTime.of(0, 0));
+        sleepAveragesResponse.setAverageTimeOutOfBed(LocalTime.of(0, 0));
+        sleepAveragesResponse.setMorningFeelingFrequencies(Arrays.stream(MorningFeeling.values())
+                .collect(Collectors.toMap(feeling -> feeling, feeling -> 0)));
+
+        return sleepAveragesResponse;
+    }
+
+    public SleepAveragesResponse toAverageResponse(LocalDate startDate, LocalDate endDate, Double averageTotalTimeInBed,
+            LocalTime averageTimeInBed, LocalTime averageTimeOutOfBed,
+            java.util.Map<MorningFeeling, Integer> morningFeelingFrequencies) {
+        SleepAveragesResponse sleepAveragesResponse = new SleepAveragesResponse();
+        sleepAveragesResponse.setDateRangeStart(startDate);
+        sleepAveragesResponse.setDateRangeEnd(endDate);
+        sleepAveragesResponse.setAverageTotalTimeInBed(averageTotalTimeInBed);
+        sleepAveragesResponse.setAverageTimeInBed(averageTimeInBed);
+        sleepAveragesResponse.setAverageTimeOutOfBed(averageTimeOutOfBed);
+        sleepAveragesResponse.setMorningFeelingFrequencies(morningFeelingFrequencies);
+
+        return sleepAveragesResponse;
+    }
+
+}

--- a/sleep/src/test/java/com/noom/interview/fullstack/sleep/business/SleepLogCalculatorTest.java
+++ b/sleep/src/test/java/com/noom/interview/fullstack/sleep/business/SleepLogCalculatorTest.java
@@ -1,0 +1,71 @@
+package com.noom.interview.fullstack.sleep.business;
+
+import com.noom.interview.fullstack.sleep.model.MorningFeeling;
+import com.noom.interview.fullstack.sleep.model.SleepLog;
+import com.noom.interview.fullstack.sleep.dto.SleepLogRequest;
+import org.junit.jupiter.api.Test;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+import java.util.List;
+import java.util.Map;
+import static org.junit.jupiter.api.Assertions.*;
+
+class SleepLogCalculatorTest {
+
+    @Test
+    void testCalculateTotalTimeInBed() {
+        SleepLogRequest request = new SleepLogRequest();
+        request.setTimeInBedStart(LocalDateTime.of(2023, 1, 1, 22, 0));
+        request.setTimeInBedEnd(LocalDateTime.of(2023, 1, 2, 6, 0));
+        int totalTime = SleepLogCalculator.calculateTotalTimeInBed(request);
+        assertEquals(480, totalTime); // 8 hours = 480 minutes
+    }
+
+    @Test
+    void testCalculateAverageTotalTimeInBed() {
+        SleepLog log1 = new SleepLog();
+        log1.setTotalTimeInBed(480); // 8 hours
+        SleepLog log2 = new SleepLog();
+        log2.setTotalTimeInBed(540); // 9 hours
+        List<SleepLog> logs = List.of(log1, log2);
+        double average = SleepLogCalculator.calculateAverageTotalTimeInBed(logs);
+        assertEquals(510.0, average, 0.001); // (480 + 540) / 2 = 510
+    }
+
+    @Test
+    void testCalculateAverageTimeInBed() {
+        SleepLog log1 = new SleepLog();
+        log1.setTimeInBedStart(LocalDateTime.of(2023, 1, 1, 22, 0));
+        SleepLog log2 = new SleepLog();
+        log2.setTimeInBedStart(LocalDateTime.of(2023, 1, 2, 23, 0));
+        List<SleepLog> logs = List.of(log1, log2);
+        LocalTime averageTime = SleepLogCalculator.calculateAverageTimeInBed(logs);
+        assertEquals(LocalTime.of(22, 30), averageTime); // Average of 22:00 and 23:00
+    }
+
+    @Test
+    void testCalculateAverageTimeOutOfBed() {
+        SleepLog log1 = new SleepLog();
+        log1.setTimeInBedEnd(LocalDateTime.of(2023, 1, 2, 6, 0));
+        SleepLog log2 = new SleepLog();
+        log2.setTimeInBedEnd(LocalDateTime.of(2023, 1, 3, 7, 0));
+        List<SleepLog> logs = List.of(log1, log2);
+        LocalTime averageTime = SleepLogCalculator.calculateAverageTimeOutOfBed(logs);
+        assertEquals(LocalTime.of(6, 30), averageTime); // Average of 6:00 and 7:00
+    }
+
+    @Test
+    void testCalculateMorningFeelingFrequencies() {
+        SleepLog log1 = new SleepLog();
+        log1.setMorningFeeling(MorningFeeling.GOOD);
+        SleepLog log2 = new SleepLog();
+        log2.setMorningFeeling(MorningFeeling.OK);
+        SleepLog log3 = new SleepLog();
+        log3.setMorningFeeling(MorningFeeling.GOOD);
+        List<SleepLog> logs = List.of(log1, log2, log3);
+        Map<MorningFeeling, Integer> frequencies = SleepLogCalculator.calculateMorningFeelingFrequencies(logs);
+        assertEquals(2, frequencies.get(MorningFeeling.GOOD));
+        assertEquals(1, frequencies.get(MorningFeeling.OK));
+        assertEquals(0, frequencies.get(MorningFeeling.BAD));
+    }
+}

--- a/sleep/src/test/java/com/noom/interview/fullstack/sleep/mapper/SleepLogMapperTest.java
+++ b/sleep/src/test/java/com/noom/interview/fullstack/sleep/mapper/SleepLogMapperTest.java
@@ -1,0 +1,146 @@
+package com.noom.interview.fullstack.sleep.mapper;
+
+import com.noom.interview.fullstack.sleep.dto.SleepAveragesResponse;
+import com.noom.interview.fullstack.sleep.dto.SleepLogRequest;
+import com.noom.interview.fullstack.sleep.dto.SleepLogResponse;
+import com.noom.interview.fullstack.sleep.model.MorningFeeling;
+import com.noom.interview.fullstack.sleep.model.SleepLog;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.entry;
+
+public class SleepLogMapperTest {
+
+    private SleepLogMapper mapper;
+
+    @BeforeEach
+    public void setUp() {
+        mapper = new SleepLogMapper();
+    }
+
+    // Tests that toRequest correctly maps a SleepLog to a SleepLogRequest.
+    @Test
+    public void testToRequest() {
+        // Arrange
+        SleepLog sleepLog = new SleepLog();
+        sleepLog.setTimeInBedStart(LocalDateTime.of(2023, 10, 15, 22, 0));
+        sleepLog.setTimeInBedEnd(LocalDateTime.of(2023, 10, 16, 6, 0));
+        sleepLog.setMorningFeeling(MorningFeeling.GOOD);
+
+        // Act
+        SleepLogRequest request = mapper.toRequest(sleepLog);
+
+        // Assert
+        assertThat(request.getTimeInBedStart()).isEqualTo(sleepLog.getTimeInBedStart());
+        assertThat(request.getTimeInBedEnd()).isEqualTo(sleepLog.getTimeInBedEnd());
+        assertThat(request.getMorningFeeling()).isEqualTo(sleepLog.getMorningFeeling());
+    }
+
+    // Tests that toEntity correctly maps a SleepLogRequest and additional
+    // parameters to a SleepLog.
+    @Test
+    public void testToEntity() {
+        // Arrange
+        SleepLogRequest request = new SleepLogRequest();
+        request.setTimeInBedStart(LocalDateTime.of(2023, 10, 15, 22, 0));
+        request.setTimeInBedEnd(LocalDateTime.of(2023, 10, 16, 6, 0));
+        request.setMorningFeeling(MorningFeeling.GOOD);
+
+        Long userId = 1L;
+        LocalDate sleepDate = LocalDate.of(2023, 10, 15);
+        int totalTimeInBed = 480; // 8 hours in minutes
+
+        // Act
+        SleepLog sleepLog = mapper.toEntity(request, userId, sleepDate, totalTimeInBed);
+
+        // Assert
+        assertThat(sleepLog.getUserId()).isEqualTo(userId);
+        assertThat(sleepLog.getSleepDate()).isEqualTo(sleepDate);
+        assertThat(sleepLog.getTimeInBedStart()).isEqualTo(request.getTimeInBedStart());
+        assertThat(sleepLog.getTimeInBedEnd()).isEqualTo(request.getTimeInBedEnd());
+        assertThat(sleepLog.getTotalTimeInBed()).isEqualTo(totalTimeInBed);
+        assertThat(sleepLog.getMorningFeeling()).isEqualTo(request.getMorningFeeling());
+    }
+
+    // Tests that toResponse correctly maps a SleepLog to a SleepLogResponse.
+    @Test
+    public void testToResponse() {
+        // Arrange
+        SleepLog sleepLog = new SleepLog();
+        sleepLog.setUserId(1L);
+        sleepLog.setSleepDate(LocalDate.of(2023, 10, 15));
+        sleepLog.setTimeInBedStart(LocalDateTime.of(2023, 10, 15, 22, 0));
+        sleepLog.setTimeInBedEnd(LocalDateTime.of(2023, 10, 16, 6, 0));
+        sleepLog.setTotalTimeInBed(480);
+        sleepLog.setMorningFeeling(MorningFeeling.GOOD);
+
+        // Act
+        SleepLogResponse response = mapper.toResponse(sleepLog);
+
+        // Assert
+        assertThat(response.getUserId()).isEqualTo(sleepLog.getUserId());
+        assertThat(response.getSleepDate()).isEqualTo(sleepLog.getSleepDate());
+        assertThat(response.getTimeInBedStart()).isEqualTo(sleepLog.getTimeInBedStart());
+        assertThat(response.getTimeInBedEnd()).isEqualTo(sleepLog.getTimeInBedEnd());
+        assertThat(response.getTotalTimeInBed()).isEqualTo(sleepLog.getTotalTimeInBed());
+        assertThat(response.getMorningFeeling()).isEqualTo(sleepLog.getMorningFeeling());
+    }
+
+    // Tests that toAverageResponseWithEmptyLogs returns a SleepAveragesResponse
+    // with default values.
+    @Test
+    public void testToAverageResponseWithEmptyLogs() {
+        // Arrange
+        LocalDate startDate = LocalDate.of(2023, 10, 1);
+        LocalDate endDate = LocalDate.of(2023, 10, 31);
+
+        // Act
+        SleepAveragesResponse response = mapper.toAverageResponseWithEmptyLogs(startDate, endDate);
+
+        // Assert
+        assertThat(response.getDateRangeStart()).isEqualTo(startDate);
+        assertThat(response.getDateRangeEnd()).isEqualTo(endDate);
+        assertThat(response.getAverageTotalTimeInBed()).isEqualTo(0.0);
+        assertThat(response.getAverageTimeInBed()).isEqualTo(LocalTime.of(0, 0));
+        assertThat(response.getAverageTimeOutOfBed()).isEqualTo(LocalTime.of(0, 0));
+        assertThat(response.getMorningFeelingFrequencies()).containsOnly(
+                entry(MorningFeeling.BAD, 0),
+                entry(MorningFeeling.OK, 0),
+                entry(MorningFeeling.GOOD, 0));
+    }
+
+    // Tests that toAverageResponse correctly maps provided averages and frequencies
+    // to a SleepAveragesResponse.
+    @Test
+    public void testToAverageResponse() {
+        // Arrange
+        LocalDate startDate = LocalDate.of(2023, 10, 1);
+        LocalDate endDate = LocalDate.of(2023, 10, 31);
+        Double averageTotalTimeInBed = 420.5; // 7 hours and 30.5 minutes
+        LocalTime averageTimeInBed = LocalTime.of(22, 30);
+        LocalTime averageTimeOutOfBed = LocalTime.of(6, 45);
+        Map<MorningFeeling, Integer> frequencies = Map.of(
+                MorningFeeling.BAD, 2,
+                MorningFeeling.OK, 5,
+                MorningFeeling.GOOD, 3);
+
+        // Act
+        SleepAveragesResponse response = mapper.toAverageResponse(startDate, endDate, averageTotalTimeInBed,
+                averageTimeInBed, averageTimeOutOfBed, frequencies);
+
+        // Assert
+        assertThat(response.getDateRangeStart()).isEqualTo(startDate);
+        assertThat(response.getDateRangeEnd()).isEqualTo(endDate);
+        assertThat(response.getAverageTotalTimeInBed()).isEqualTo(averageTotalTimeInBed);
+        assertThat(response.getAverageTimeInBed()).isEqualTo(averageTimeInBed);
+        assertThat(response.getAverageTimeOutOfBed()).isEqualTo(averageTimeOutOfBed);
+        assertThat(response.getMorningFeelingFrequencies()).containsExactlyInAnyOrderEntriesOf(frequencies);
+    }
+}


### PR DESCRIPTION
### Overview
This PR introduces the Mapper and Business layers for the Sleep API, including `SleepLogMapper` for DTO-entity mapping and `SleepLogCalculator` for sleep metric calculations. Unit tests ensure the reliability of these components. The files were recovered after an accidental commit and reset on the wrong branch.

### Changes
- **Mapper Layer**:
  - Added `SleepLogMapper` to handle conversions between DTOs (`SleepLogRequest`, `SleepLogResponse`, `SleepAveragesResponse`) and entities (`SleepLog`).
  - Supports mapping for creating sleep logs and calculating averages.
- **Business Layer**:
  - Added `SleepLogCalculator` with static methods:
    - `calculateTotalTimeInBed`: Computes total time in bed from a `SleepLogRequest`.
    - `calculateAverageTotalTimeInBed`: Calculates average total time in bed.
    - `calculateAverageTimeInBed`: Computes average bedtime.
    - `calculateAverageTimeOutOfBed`: Computes average wake-up time.
    - `calculateMorningFeelingFrequencies`: Calculates frequency of `MorningFeeling` values.
- **Tests**:
  - Added `SleepLogMapperTest` to verify mapping logic.
  - Added `SleepLogCalculatorTest` to validate all calculation methods.
  - All tests pass (`./gradlew test`).

### Why This Change?
- The Mapper layer ensures clean separation between API-facing DTOs and database entities.
- The Business layer provides reusable utility methods for sleep calculations, enhancing modularity.
- Unit tests provide confidence in the correctness of these components.

### Testing
- Ran `./gradlew test`—all tests pass.
- Verified edge cases in unit tests (e.g., null inputs, empty lists).

### Checklist
- [x] Code follows project style guidelines.
- [x] Unit tests added and passing.
- [x] No new warnings or errors in build.