### PR TITLE
Add Postman collection and bash script

### DIFF
--- a/ArsFutura Noom.postman_collection.json
+++ b/ArsFutura Noom.postman_collection.json
@@ -1,0 +1,287 @@
+{
+	"info": {
+		"_postman_id": "348f5df1-1d88-4258-9953-04a96c0539a5",
+		"name": "ArsFutura Noom",
+		"description": "# 🚀 Get started here\n\n  \nThere is a script in the root of project called test-api.sh  \n  \nOn Mac/Linux run\n\n``` bash\nchmod +x test-api.sh\n\n ```\n\nTo make sure the script is executable  \n  \nThan you can run the script with command\n\n``` bash\n./test-api.sh\n\n ```",
+		"schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json",
+		"_exporter_id": "15997640",
+		"_collection_link": "https://red-spaceship-47159.postman.co/workspace/My-Workspace~5abfd106-b287-4a13-8f5b-32a8646d2e1b/collection/15997640-348f5df1-1d88-4258-9953-04a96c0539a5?action=share&source=collection_link&creator=15997640"
+	},
+	"item": [
+		{
+			"name": "Main",
+			"item": [
+				{
+					"name": "Get Last Night Sleep",
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"exec": [
+									"pm.test(\"Status code is 200\", function () {",
+									"    pm.response.to.have.status(200);",
+									"});"
+								],
+								"type": "text/javascript",
+								"packages": {}
+							}
+						}
+					],
+					"request": {
+						"method": "GET",
+						"header": [],
+						"url": {
+							"raw": "{{base_url}}/api/sleep/{{id}}/last-night",
+							"host": [
+								"{{base_url}}"
+							],
+							"path": [
+								"api",
+								"sleep",
+								"{{id}}",
+								"last-night"
+							]
+						},
+						"description": "This is a GET request and it is used to \"get\" data from an endpoint. There is no request body for a GET request, but you can use query parameters to help specify the resource you want data on (e.g., in this request, we have `id=1`).\n\nA successful GET response will have a `200 OK` status, and should include some kind of response body - for example, HTML web content or JSON data."
+					},
+					"response": []
+				},
+				{
+					"name": "Get Last 30 Day Averages",
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"exec": [
+									"pm.test(\"Successful POST request\", function () {",
+									"    pm.expect(pm.response.code).to.be.oneOf([200, 201]);",
+									"});",
+									""
+								],
+								"type": "text/javascript",
+								"packages": {}
+							}
+						}
+					],
+					"request": {
+						"method": "GET",
+						"header": [],
+						"url": {
+							"raw": "{{base_url}}/api/sleep/{{id}}/averages",
+							"host": [
+								"{{base_url}}"
+							],
+							"path": [
+								"api",
+								"sleep",
+								"{{id}}",
+								"averages"
+							]
+						},
+						"description": "This is a POST request, submitting data to an API via the request body. This request submits JSON data, and the data is reflected in the response.\n\nA successful POST request typically returns a `200 OK` or `201 Created` response code."
+					},
+					"response": []
+				},
+				{
+					"name": "Create Sleep Log",
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"exec": [
+									"pm.test(\"Successful POST request\", function () {",
+									"    pm.expect(pm.response.code).to.be.oneOf([200, 201]);",
+									"});",
+									""
+								],
+								"type": "text/javascript",
+								"packages": {}
+							}
+						}
+					],
+					"request": {
+						"method": "POST",
+						"header": [],
+						"body": {
+							"mode": "raw",
+							"raw": "{\n\t\"timeInBedStart\": \"2025-05-19T23:48:08.644\",\n    \"timeInBedEnd\": \"2025-05-20T06:15:08.644\",\n    \"morningFeeling\": \"OK\"\n}",
+							"options": {
+								"raw": {
+									"language": "json"
+								}
+							}
+						},
+						"url": {
+							"raw": "{{base_url}}/api/sleep/{{id}}",
+							"host": [
+								"{{base_url}}"
+							],
+							"path": [
+								"api",
+								"sleep",
+								"{{id}}"
+							]
+						},
+						"description": "This is a POST request, submitting data to an API via the request body. This request submits JSON data, and the data is reflected in the response.\n\nA successful POST request typically returns a `200 OK` or `201 Created` response code."
+					},
+					"response": []
+				}
+			]
+		},
+		{
+			"name": "Debug",
+			"item": [
+				{
+					"name": "Get Last Night Sleep Dbg",
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"exec": [
+									"pm.test(\"Status code is 200\", function () {",
+									"    pm.response.to.have.status(200);",
+									"});"
+								],
+								"type": "text/javascript",
+								"packages": {}
+							}
+						}
+					],
+					"request": {
+						"method": "GET",
+						"header": [],
+						"url": {
+							"raw": "{{debug_base_url}}/api/sleep/{{id}}/last-night",
+							"host": [
+								"{{debug_base_url}}"
+							],
+							"path": [
+								"api",
+								"sleep",
+								"{{id}}",
+								"last-night"
+							]
+						},
+						"description": "This is a GET request and it is used to \"get\" data from an endpoint. There is no request body for a GET request, but you can use query parameters to help specify the resource you want data on (e.g., in this request, we have `id=1`).\n\nA successful GET response will have a `200 OK` status, and should include some kind of response body - for example, HTML web content or JSON data."
+					},
+					"response": []
+				},
+				{
+					"name": "Get Last 30 Day Averages Dbg",
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"exec": [
+									"pm.test(\"Successful POST request\", function () {",
+									"    pm.expect(pm.response.code).to.be.oneOf([200, 201]);",
+									"});",
+									""
+								],
+								"type": "text/javascript",
+								"packages": {}
+							}
+						}
+					],
+					"request": {
+						"method": "GET",
+						"header": [],
+						"url": {
+							"raw": "{{debug_base_url}}/api/sleep/{{id}}/averages",
+							"host": [
+								"{{debug_base_url}}"
+							],
+							"path": [
+								"api",
+								"sleep",
+								"{{id}}",
+								"averages"
+							]
+						},
+						"description": "This is a POST request, submitting data to an API via the request body. This request submits JSON data, and the data is reflected in the response.\n\nA successful POST request typically returns a `200 OK` or `201 Created` response code."
+					},
+					"response": []
+				},
+				{
+					"name": "Create Sleep Log Dbg",
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"exec": [
+									"pm.test(\"Successful POST request\", function () {",
+									"    pm.expect(pm.response.code).to.be.oneOf([200, 201]);",
+									"});",
+									""
+								],
+								"type": "text/javascript",
+								"packages": {}
+							}
+						}
+					],
+					"request": {
+						"method": "POST",
+						"header": [],
+						"body": {
+							"mode": "raw",
+							"raw": "{\n\t\"timeInBedStart\": \"2025-01-23T05:47:08.644\",\n    \"timeInBedEnd\": \"2025-01-23T13:47:08.644\",\n    \"morningFeeling\": \"GOOD\"\n}",
+							"options": {
+								"raw": {
+									"language": "json"
+								}
+							}
+						},
+						"url": {
+							"raw": "{{debug_base_url}}/api/sleep/{{id}}",
+							"host": [
+								"{{debug_base_url}}"
+							],
+							"path": [
+								"api",
+								"sleep",
+								"{{id}}"
+							]
+						},
+						"description": "This is a POST request, submitting data to an API via the request body. This request submits JSON data, and the data is reflected in the response.\n\nA successful POST request typically returns a `200 OK` or `201 Created` response code."
+					},
+					"response": []
+				}
+			]
+		}
+	],
+	"event": [
+		{
+			"listen": "prerequest",
+			"script": {
+				"type": "text/javascript",
+				"exec": [
+					""
+				]
+			}
+		},
+		{
+			"listen": "test",
+			"script": {
+				"type": "text/javascript",
+				"exec": [
+					""
+				]
+			}
+		}
+	],
+	"variable": [
+		{
+			"key": "id",
+			"value": "1"
+		},
+		{
+			"key": "base_url",
+			"value": "http://localhost:8080"
+		},
+		{
+			"key": "debug_base_url",
+			"value": "http://localhost:8081",
+			"type": "string"
+		}
+	]
+}

--- a/test-api.sh
+++ b/test-api.sh
@@ -1,0 +1,95 @@
+#!/bin/bash
+
+# Get the current date and calculate the start date (30 days ago)
+CURRENT_DATE=$(date +%Y-%m-%d)  # 2025-05-25
+START_DATE=$(date -d "30 days ago $CURRENT_DATE" +%Y-%m-%d)  # 2025-04-25
+
+# Extract year, month, and day from current and start dates
+CURRENT_YEAR=$(date -d "$CURRENT_DATE" +%Y)  # 2025
+CURRENT_MONTH=$(date -d "$CURRENT_DATE" +%m) # 05
+CURRENT_DAY=$(date -d "$CURRENT_DATE" +%d)   # 25
+START_YEAR=$(date -d "$START_DATE" +%Y)      # 2025
+START_MONTH=$(date -d "$START_DATE" +%m)     # 04
+START_DAY=$(date -d "$START_DATE" +%d)       # 25
+
+# Array to store morning feelings
+MORNING_FEELINGS=("GOOD" "BAD" "OK")
+
+# Initialize the sleep_logs array
+sleep_logs=()
+
+# Function to get the number of days in a month
+days_in_month() {
+    date -d "$1-01 + 1 month - 1 day" +%d
+}
+
+# Loop through each day from START_DATE to CURRENT_DATE
+CURRENT_DATE_EPOCH=$(date -d "$CURRENT_DATE" +%s)
+START_DATE_EPOCH=$(date -d "$START_DATE" +%s)
+for ((epoch=START_DATE_EPOCH; epoch<=CURRENT_DATE_EPOCH; epoch+=86400)); do
+    DATE=$(date -d "@$epoch" +%Y-%m-%d)
+    YEAR=$(date -d "$DATE" +%Y)
+    MONTH=$(date -d "$DATE" +%m)
+    DAY=$(date -d "$DATE" +%d)
+
+    # Generate random times
+    START_HOUR=$((RANDOM % 2 + 22))  # 22 or 23
+    START_MINUTE=$((RANDOM % 60))
+    START_SECOND=$((RANDOM % 60))
+    
+    # timeInBedEnd: Next day, random hour between 5 and 8
+    END_HOUR=$((RANDOM % 4 + 5))  # 5 to 8
+    END_MINUTE=$((RANDOM % 60))
+    END_SECOND=$((RANDOM % 60))
+    
+    # Calculate the next day for timeInBedEnd
+    NEXT_DATE=$(date -d "$DATE + 1 day" +%Y-%m-%d)
+    NEXT_YEAR=$(date -d "$NEXT_DATE" +%Y)
+    NEXT_MONTH=$(date -d "$NEXT_DATE" +%m)
+    NEXT_DAY=$(date -d "$NEXT_DATE" +%d)
+
+    # Randomly select a morning feeling
+    RANDOM_FEELING=${MORNING_FEELINGS[$((RANDOM % 3))]}
+
+    # Construct the JSON payload
+    JSON='{"timeInBedStart": "'$YEAR'-'$MONTH'-'$DAY'T'$START_HOUR':'$(printf "%02d" $START_MINUTE)':'$(printf "%02d" $START_SECOND)'.644","timeInBedEnd": "'$NEXT_YEAR'-'$NEXT_MONTH'-'$NEXT_DAY'T'$(printf "%02d" $END_HOUR)':'$(printf "%02d" $END_MINUTE)':'$(printf "%02d" $END_SECOND)'.644","morningFeeling": "'$RANDOM_FEELING'"}'
+
+    # Add to the sleep_logs array
+    sleep_logs+=("$JSON")
+done
+
+# Test 1: Create a sleep log for user with id 1
+echo "Starting the Sleep API tests..."
+echo "----------------------------------------"
+echo "Test 1: Create a sleep log for user with id 1"
+echo "----------------------------------------"   
+# Print the array (for debugging)
+echo "Generated sleep_logs array for the last 30 days (from $START_DATE to $CURRENT_DATE):"
+printf '%s\n' "${sleep_logs[@]}"
+echo "----------------------------------------"   
+echo "Creating a sleep log for user with id 1..."
+# Loop through the array and make POST requests
+for log in "${sleep_logs[@]}"; do
+    echo "Adding sleep log: $log"
+    curl -X POST http://localhost:8080/api/sleep/1 \
+         -H "Content-Type: application/json" \
+         -d "$log"
+    echo -e "\n"
+done
+echo "----------------------------------------"
+
+# Test 2: Fetch last night sleep logs for user with id 1
+echo "Test 2: Fetch last night sleep logs for user with id 1"
+echo "----------------------------------------"
+echo "Fetching last night sleep logs for with id 1..."
+curl http://localhost:8080/api/sleep/1/last-night
+echo -e "\n"
+echo "----------------------------------------"
+
+# Test 3: Fetch 30 day averages
+echo "Test 3: Fetch 30 day averages for user with id 1"
+echo "----------------------------------------"
+echo "Fetching 30 day averages for user with id 1..."
+curl http://localhost:8080/api/sleep/1/averages
+echo -e "\n"
+echo "----------------------------------------"


### PR DESCRIPTION
### Overview
This PR gives us Postman collection with REST api endpoints and bash script for testing and populating data. 

### Changes
- **Root**:
  - Added `ArsFutura Noom.postman_collection` with endpoints:
    - `POST /api/sleep/{userId}` to create a sleep log.
    - `GET /api/sleep/{userId}/last-night` to fetch the last night's sleep log.
    - `GET /api/sleep/{userId}/averages` to fetch 30-day averages.
- **Bash script**:
  - Added `test-api` for testing and populating data.

### Why This Change?
- To provide users with ready to go REST api endpoints
- To provide users with starting data in database.

### Runngin
- Make sure the script is executable `chmod +x test-api.sh`
- Run the script `./test-api.sh`

### Checklist
- [x] No new warnings or errors in build.